### PR TITLE
Bugfix/13967 memcached darklist is not added after rb bootstrap (#71)

### DIFF
--- a/resources/recipes/configure_cron_tasks.rb
+++ b/resources/recipes/configure_cron_tasks.rb
@@ -119,6 +119,7 @@ cron_d 'rb_update_darklist_weekly' do
   retries 2
   ignore_failure true
   command "/usr/lib/redborder/bin/rb_update_darklist.sh"
+  notifies :run, 'execute[populate_darklist]', :delayed
 end
 
 cron_d 'refresh_darklist_memcached_keys_hourly' do
@@ -129,4 +130,9 @@ cron_d 'refresh_darklist_memcached_keys_hourly' do
   retries 2
   ignore_failure true
   command "/usr/lib/redborder/bin/rb_refresh_darklist_memcached_keys.sh"
+end
+
+execute 'populate_darklist' do
+  command '/usr/lib/redborder/bin/rb_update_darklist.sh -f'
+  action :nothing
 end


### PR DESCRIPTION
* Added geoipupdate cron job

* Removed verbose mode to geoipupdate and changed its path

* Execute populate_darklist after creation of darklist cronjobs

* Removed geoipupdate cron job