### PR TITLE
Bugfix/15042 rbmonitor cluster

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -165,8 +165,6 @@ snmp_config "Configure snmp" do
   action (manager_services["snmp"] ? :add : :remove)
 end
 
-monitor_dg = Chef::DataBagItem.load("rBglobal", "monitors") rescue monitor_dg = {}
-
 rbmonitor_config "Configure redborder-monitor" do
   name node["hostname"]
   device_nodes node["redborder"]["sensors_info_all"]["device-sensor"]
@@ -174,7 +172,6 @@ rbmonitor_config "Configure redborder-monitor" do
   managers node["redborder"]["managers_list"]
   cluster node["redborder"]["cluster_info"]
   hostip node["redborder"]["cluster_info"][name]["ip"]
-  monitor_dg
   action (manager_services["redborder-monitor"] ? :add : :remove)
 end
 

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -165,12 +165,16 @@ snmp_config "Configure snmp" do
   action (manager_services["snmp"] ? :add : :remove)
 end
 
+monitor_dg = Chef::DataBagItem.load("rBglobal", "monitors") rescue monitor_dg = {}
+
 rbmonitor_config "Configure redborder-monitor" do
   name node["hostname"]
   device_nodes node["redborder"]["sensors_info_all"]["device-sensor"]
   flow_nodes node["redborder"]["sensors_info_all"]["flow-sensor"]
   managers node["redborder"]["managers_list"]
   cluster node["redborder"]["cluster_info"]
+  hostip node["redborder"]["cluster_info"][name]["ip"]
+  monitor_dg
   action (manager_services["redborder-monitor"] ? :add : :remove)
 end
 


### PR DESCRIPTION
[Bug #15042: 6.1 Monitor is not working in cluster mode](https://redmine.redborder.lan/issues/15042)

Additions:
- Added an attribute to send the _hostip_ to cookbook-rb-monitor, used in the creation of the final config file for the _Monitor_ module