### PR TITLE
Feature/15586 integrate rb aioutliers in ng

### DIFF
--- a/packaging/rpm/cookbook-rb-manager.spec
+++ b/packaging/rpm/cookbook-rb-manager.spec
@@ -45,21 +45,21 @@ esac
 %doc
 
 %changelog
-* Wed Sep 27 2023 Miguel Álvarez <malvarez@redborder.com> - 1.5.16
+* Wed Sep 27 2023 Miguel Álvarez <malvarez@redborder.com> - 1.5.17-1
 - Add dependencies for rb-aioutliers cookbook
-* Mon Jun 26 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.15
+* Mon Jun 26 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.15-1
 - GeoIP removed from service list
-* Fri May 05 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.12
+* Fri May 05 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.12-1
 - Tiers added for druid historical
-* Thu May 04 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.11
+* Thu May 04 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.11-1
 - Add Ohai
-* Mon Apr 24 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.10
+* Mon Apr 24 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.10-1
 - Permission scalling
-* Tue Apr 18 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.9
+* Tue Apr 18 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.9-1
 - device sensor
-* Wed Feb 15 2023 Luis Blanco <ljblanco@redborder.com> - 1.5.8
+* Wed Feb 15 2023 Luis Blanco <ljblanco@redborder.com> - 1.5.8-1
 - sensors info updated and filtered by parent_id
-* Fri Feb 3 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.7
+* Fri Feb 3 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.7-1
 - integrate freeradius in proxy
 * Fri Jan 28 2022 David Vanhoucke <dvanhoucke@redborder.com> - 1.2.8-1
 - exchange s3 attributes with druid

--- a/packaging/rpm/cookbook-rb-manager.spec
+++ b/packaging/rpm/cookbook-rb-manager.spec
@@ -45,6 +45,8 @@ esac
 %doc
 
 %changelog
+* Wed Sep 27 2023 Miguel Álvarez <malvarez@redborder.com> - 1.5.16
+- Add dependencies for rb-aioutliers cookbook
 * Mon Jun 26 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.15
 - GeoIP removed from service list
 * Fri May 05 2023 Luis J. Blanco <ljblanco@redborder.com> - 1.5.12

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -91,6 +91,7 @@ default["redborder"]["memory_services"]["redborder-social"] = {"count" => 10, "m
 default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["redborder-cep"] = {"count" => 10, "memory" => 0 }
+default["redborder"]["memory_services"]["rb-aioutliers"] = {"count" => 5, "memory" => 0 }
 
 # default attributes for managers_info, it would be rewriten with the cluster config
 default["redborder"]["cluster_info"] = {}
@@ -110,7 +111,7 @@ default["redborder"]["services_group"]["full"] = %w[consul chef-server zookeeper
                                                     druid-historical druid-realtime druid-coordinator f2k
                                                     redborder-monitor redborder-scanner pmacct redborder-dswatcher
                                                     redborder-events-counter http2k redborder-social redborder-nmsp
-                                                    n2klocd redborder-ale radiusd redborder-cep] #geoip removed
+                                                    n2klocd redborder-ale radiusd redborder-cep rb-aioutliers] #geoip removed
 default["redborder"]["services_group"]["custom"] = []
 default["redborder"]["services_group"]["core"] = %w[consul zookeeper druid-coordinator druid-overlord hadoop-resourcemanager] #consul server
 default["redborder"]["services_group"]["chef"] = %w[chef-server]
@@ -145,6 +146,7 @@ default["redborder"]["services"]["postgresql"]                = false
 default["redborder"]["services"]["redborder-postgresql"]      = false
 default["redborder"]["services"]["nginx"]                     = false
 default["redborder"]["services"]["redborder-cep"]             = false
+default["redborder"]["services"]["rb-aioutliers"]             = false
 default["redborder"]["services"]["memcached"]                 = true
 default["redborder"]["services"]["rb-monitor"]                = false
 default["redborder"]["services"]["secor"]                     = false
@@ -184,6 +186,7 @@ default["redborder"]["systemdservices"]["postgresql"]             = ["postgresql
 default["redborder"]["systemdservices"]["redborder-postgresql"]   = ["redborder-postgresql"]
 default["redborder"]["systemdservices"]["nginx"]                  = ["nginx"]
 default["redborder"]["systemdservices"]["redborder-cep"]          = ["redborder-cep"]
+default["redborder"]["systemdservices"]["rb-aioutliers"]          = ["rb-aioutliers"]
 default["redborder"]["systemdservices"]["memcached"]              = ["memcached"]
 default["redborder"]["systemdservices"]["s3"]                     = ["minio"]
 default["redborder"]["systemdservices"]["mongodb"]                = ["mongod"]

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'manegron@redborder.com'
 license          'All rights reserved'
 description      'Installs/Configures redborder manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.18'
+version          '0.0.19'
 
 depends 'chef-server'
 depends 'zookeeper'
@@ -39,3 +39,4 @@ depends 'freeradius'
 depends 'rbcep'
 depends 'cron'
 depends 'ohai'
+depends 'rbaioutliers'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'manegron@redborder.com'
 license          'All rights reserved'
 description      'Installs/Configures redborder manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.19'
+version          '1.5.17'
 
 depends 'chef-server'
 depends 'zookeeper'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -294,6 +294,10 @@ rbale_config "Configure redborder-ale" do
   action (node["redborder"]["services"]["redborder-ale"] ? [:add, :register] : [:remove, :deregister])
 end
 
+rbaioutliers_config "Configure rb-aioutliers" do
+  action [:add]
+end
+
 freeradius_config "Configure radiusd" do
   flow_nodes node["redborder"]["sensors_info_all"]["flow-sensor"]
   action (node["redborder"]["services"]["radiusd"] ? [:config_common, :config_manager, :register] : [:remove, :deregister])


### PR DESCRIPTION
This PR introduces next changes to rb-manager cookbook.

1 -. Add dependency of rb-aioutiers cookbook
2 -. Add chef template for config.ini of rb-aioutliers service
3 -. Updated version format in spec file