### PR TITLE
druid realtime zookeeper host is overriden because the realtime spec is using hardcoded localhost

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -136,6 +136,7 @@ end
 druid_realtime "Configure Druid Realtime" do
   name node["hostname"]
   ipaddress node["ipaddress_sync"]
+  zookeeper_hosts node["redborder"]["zookeeper"]["zk_hosts"]
   memory_kb node["redborder"]["memory_services"]["druid-realtime"]["memory"]
   action (manager_services["druid-realtime"] ? [:add, :register] : [:remove, :deregister])
 end


### PR DESCRIPTION
Druid realtime is using hardcoded zookeeper connection to localhost

```
 "zookeeper.connect": "localhost:2181",
```

Now it should use

```
"zookeeper.connect":"zookeeper.service.redborder.cluster:2181",
```