### PR TITLE
Druid realtime is not acting as a cluster because shardSpec partition is not correctly set

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -211,5 +211,7 @@ default["redborder"]["systemdservices"]["radiusd"]                = ["radiusd"]
 default["redborder"]["druid"]["historical"]["tier"]     = "default"
 default["redborder"]["druid"]["historical"]["maxsize"]  = -1
 
+# Realtime
+default["redborder"]["druid"]["realtime"]["partition_num"] = 0
 
 default["redborder"]["pending_changes"]=0

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -136,8 +136,8 @@ end
 druid_realtime "Configure Druid Realtime" do
   name node["hostname"]
   ipaddress node["ipaddress_sync"]
-  partition_num node["redborder"]["druid"]["realtime"]["partition_num"]
   zookeeper_hosts node["redborder"]["zookeeper"]["zk_hosts"]
+  partition_num node["redborder"]["druid"]["realtime"]["partition_num"]
   memory_kb node["redborder"]["memory_services"]["druid-realtime"]["memory"]
   action (manager_services["druid-realtime"] ? [:add, :register] : [:remove, :deregister])
 end

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -136,6 +136,7 @@ end
 druid_realtime "Configure Druid Realtime" do
   name node["hostname"]
   ipaddress node["ipaddress_sync"]
+  partition_num node["redborder"]["druid_realtime"]["partition_num"]
   memory_kb node["redborder"]["memory_services"]["druid-realtime"]["memory"]
   action (manager_services["druid-realtime"] ? [:add, :register] : [:remove, :deregister])
 end

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -136,7 +136,8 @@ end
 druid_realtime "Configure Druid Realtime" do
   name node["hostname"]
   ipaddress node["ipaddress_sync"]
-  partition_num node["redborder"]["druid_realtime"]["partition_num"]
+  partition_num node["redborder"]["druid"]["realtime"]["partition_num"]
+  zookeeper_hosts node["redborder"]["zookeeper"]["zk_hosts"]
   memory_kb node["redborder"]["memory_services"]["druid-realtime"]["memory"]
   action (manager_services["druid-realtime"] ? [:add, :register] : [:remove, :deregister])
 end

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -108,8 +108,8 @@ if node["redborder"]["managers_per_services"]["kafka"].include?(node.name)
 end
 
 #set druid realtime partition id (its needed in cluster mode for druid brokers)
-if node["redborder"]["manager_per_services"]["druid_realtime"].include?(node.name)
-  node.default["redborder"]["druid"]["realtime"]["partition_num"] = node["redborder"]["manager_per_services"]["druid_realtime"].index(node.name)
+if node["redborder"]["managers_per_services"]["druid-realtime"].include?(node.name)
+  node.default["redborder"]["druid"]["realtime"]["partition_num"] = node["redborder"]["managers_per_services"]["druid-realtime"].index(node.name)
 end
 
 #get an array of managers

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -107,6 +107,11 @@ if node["redborder"]["managers_per_services"]["kafka"].include?(node.name)
   node.default["redborder"]["kafka"]["host_index"] = node["redborder"]["managers_per_services"]["kafka"].index(node.name)
 end
 
+#set druid realtime partition id (its needed in cluster mode for druid brokers)
+if node["redborder"]["manager_per_services"]["druid_realtime"].include?(node.name)
+  node.default["redborder"]["druid_realtime"]["partition_num"] = node["redborder"]["manager_per_services"]["druid_realtime"].index(node.name)
+end
+
 #get an array of managers
 managers_list = []
 node["redborder"]["cluster_info"].each_key do |mgr|

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -109,7 +109,7 @@ end
 
 #set druid realtime partition id (its needed in cluster mode for druid brokers)
 if node["redborder"]["manager_per_services"]["druid_realtime"].include?(node.name)
-  node.default["redborder"]["druid_realtime"]["partition_num"] = node["redborder"]["manager_per_services"]["druid_realtime"].index(node.name)
+  node.default["redborder"]["druid"]["realtime"]["partition_num"] = node["redborder"]["manager_per_services"]["druid_realtime"].index(node.name)
 end
 
 #get an array of managers


### PR DESCRIPTION
In real-time indexing, each node or task in the indexing service generates and serves segments with a single partition number. Shard specs determine how these segments are advertised, often utilizing linear shard specs, where only the partition number needs to be specified, `the broker assumes that nodes with the same partition number contain the same data. Consequently, it only queries one of them`.