### PR TITLE
excluding chef-client not to be a memservice

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,4 +1,4 @@
-require 'set' # In case of reapeating, set will handle. Array won't
+# require 'set' # In case of reapeating, set will handle. Array won't. TODO: refactor to this line
 #Default attributes
 
 #general
@@ -94,7 +94,8 @@ default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" =>
 default["redborder"]["memory_services"]["redborder-cep"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["rb-aioutliers"] = {"count" => 10, "memory" => 0 }
 # excluded mem services
-default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # Don't assign memory to chef because the service will get handled
+# default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # TODO: refactor to this line
+default['redborder']['excluded_memservices'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
 
 # default attributes for managers_info, it would be rewriten with the cluster config
 default["redborder"]["cluster_info"] = {}

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -95,7 +95,7 @@ default["redborder"]["memory_services"]["redborder-cep"] = {"count" => 10, "memo
 default["redborder"]["memory_services"]["rb-aioutliers"] = {"count" => 10, "memory" => 0 }
 # excluded mem services
 # default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # TODO: refactor to this line
-default['redborder']['excluded_memservices'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
+default['redborder']['excluded_memory_services'] = %w[chef-client] # Don't assign memory to chef because the service will get handled
 
 # default attributes for managers_info, it would be rewriten with the cluster config
 default["redborder"]["cluster_info"] = {}

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,4 +1,3 @@
-# require 'set' # In case of reapeating, set will handle. Array won't. TODO: refactor to this line
 #Default attributes
 
 #general
@@ -93,9 +92,9 @@ default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "mem
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["redborder-cep"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["rb-aioutliers"] = {"count" => 10, "memory" => 0 }
-# excluded mem services
-# default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # TODO: refactor to this line
-default['redborder']['excluded_memory_services'] = %w[chef-client] # Don't assign memory to chef because the service will get handled
+
+# exclude mem services, setting memory to 0 for each.
+default['redborder']['excluded_memory_services'] = %w[chef-client]
 
 # default attributes for managers_info, it would be rewriten with the cluster config
 default["redborder"]["cluster_info"] = {}

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,3 +1,4 @@
+require 'set' # In case of reapeating, set will handle. Array won't
 #Default attributes
 
 #general
@@ -92,6 +93,8 @@ default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "mem
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["redborder-cep"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["rb-aioutliers"] = {"count" => 10, "memory" => 0 }
+# excluded mem services
+default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # Don't assign memory to chef because the service will get handled
 
 # default attributes for managers_info, it would be rewriten with the cluster config
 default["redborder"]["cluster_info"] = {}

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -1,6 +1,6 @@
 module Rb_manager
   module Helpers
-    def memory_services(sysmem_total, excluded_services=[])
+    def memory_services(sysmem_total, excluded_services)
       memory_serv = {}
       memory_services_size = 0
       memory_services_size_total = 0

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -1,6 +1,6 @@
 module Rb_manager
   module Helpers
-    def memory_services(sysmem_total, excluded_services)
+    def memory_services(sysmem_total, excluded_services=[])
       memory_serv = {}
       memory_services_size = 0
       memory_services_size_total = 0

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -9,7 +9,9 @@ module Rb_manager
       
       node["redborder"]["memory_services"].each do |name,mem_s|
         if node["redborder"]["services"][name] and !excluded_services.include?(name)
-          memory_services_size = memory_services_size + mem_s["count"] 
+          if !node["redborder"]["excluded_memory_services"].include?(name)
+            memory_services_size = memory_services_size + mem_s["count"] 
+          end
         end
         memory_services_size_total = memory_services_size_total + mem_s["count"]
       end
@@ -24,17 +26,18 @@ module Rb_manager
       node["redborder"]["memory_services"].each do |name,mem_s|
        
         if node["redborder"]["services"][name] and !excluded_services.include?(name) 
-               
-          # service count memory assigned * system memory / assigned services memory size
-          memory_serv[name] = (mem_s["count"] * sysmem_total / memory_services_size).round
-          #if the service has a limit of memory, we have to recalculate all using recursivity
-          if !mem_s["max_limit"].nil? and memory_serv[name] > mem_s["max_limit"]
-            memlimit_found = true
-            excluded_services << name
-            #assigning the limit of memory for this service
-            node.default["redborder"]["memory_services"][name]["memory"] = mem_s["max_limit"]
-            #now we have to take off the memory excluded from the total to recalculate memory wihout excluded services by limit
-            sysmem_total_limitsless = sysmem_total - mem_s["max_limit"]
+          if !node["redborder"]["excluded_memory_services"].include?(name)
+            # service count memory assigned * system memory / assigned services memory size
+            memory_serv[name] = (mem_s["count"] * sysmem_total / memory_services_size).round
+            #if the service has a limit of memory, we have to recalculate all using recursivity
+            if !mem_s["max_limit"].nil? and memory_serv[name] > mem_s["max_limit"]
+              memlimit_found = true
+              excluded_services << name
+              #assigning the limit of memory for this service
+              node.default["redborder"]["memory_services"][name]["memory"] = mem_s["max_limit"]
+              #now we have to take off the memory excluded from the total to recalculate memory wihout excluded services by limit
+              sysmem_total_limitsless = sysmem_total - mem_s["max_limit"]
+            end
           end
         end
       end

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -130,7 +130,7 @@ node.default["redborder"]["manager"]["hd_services_current"] = harddisk_services(
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, node.default['redborder']['excluded_memory_services'])
+memory_services(sysmem_total)
 
 #License
 

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -130,7 +130,7 @@ node.default["redborder"]["manager"]["hd_services_current"] = harddisk_services(
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, node['redborder']['excluded_memservices'])
+memory_services(sysmem_total, node['redborder']['excluded_memory_services'])
 
 #License
 

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -130,7 +130,7 @@ node.default["redborder"]["manager"]["hd_services_current"] = harddisk_services(
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, ['chef-client']) # Don't assign memory to chef because the service will get handled
+memory_services(sysmem_total, node['redborder']['excluded_memservices'])
 
 #License
 

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Cookbook Name:: manager
 # Recipe:: prepare_system
 #
@@ -8,103 +8,103 @@
 #
 extend Rb_manager::Helpers
 
-# Clean metadata to get packages upgrades
-execute 'Clean yum metadata' do
-  command 'yum clean metadata'
+#clean metadata to get packages upgrades
+execute "Clean yum metadata" do
+  command "yum clean metadata"
 end
 
 # Set services_group related with the node mode (core, full, ...)
-mode = node['redborder']['mode']
-node['redborder']['services_group'][mode].each do |s|
-  node.default['redborder']['services'][s] = true
+mode = node["redborder"]["mode"]
+node["redborder"]["services_group"][mode].each do |s|
+  node.default["redborder"]["services"][s] = true
 end
-if mode != 'core' or mode != 'full'
- node.default['redborder']['services']['consul-client'] = true
+if mode != "core" or mode != "full"
+ node.default["redborder"]["services"]["consul-client"] = true
 end
 
 #Set :ipaddress_sync
-ipaddress_sync=node['ipaddress']
+ipaddress_sync=node["ipaddress"]
 sync_net = `cat /etc/redborder/rb_init_conf.yml  | grep sync_net | awk '{print $2'} | sed 's|/.*||'`.strip
 node['network']['interfaces'].each do |interface, details|
-  next unless "x#{interface}" != 'xlo'
+  next unless "x#{interface}" != "xlo"
   ipaddress_sync = `ip route get #{sync_net} | head -n 1 | awk '{for (i=1; i<=NF; i++) if ($i == "src") print $(i+1)}'`.strip
 end
 node.default[:ipaddress_sync]=ipaddress_sync
 
 #get mac
 mac_sync = `ip a | grep -w -B2 #{ipaddress_sync} | awk '{print toupper($2)}' | head -n 1 | tr -d '\n'`
-node.default['mac_sync'] = mac_sync
+node.default["mac_sync"] = mac_sync
 
 #Configure and enable chef-client
-dnf_package 'redborder-chef-client' do
+dnf_package "redborder-chef-client" do
   flush_cache [:before]
   action :upgrade
 end
 
-template '/etc/sysconfig/chef-client' do
-  source 'sysconfig_chef-client.rb'
+template "/etc/sysconfig/chef-client" do
+  source "sysconfig_chef-client.rb"
   mode 0644
   variables(
-    :interval => node['chef-client']['interval'],
-    :splay => node['chef-client']['splay'],
-    :options => node['chef-client']['options']
+    :interval => node["chef-client"]["interval"],
+    :splay => node["chef-client"]["splay"],
+    :options => node["chef-client"]["options"]
   )
 end
 
-if node['redborder']['services']['chef-client']
-  service 'chef-client' do
+if node["redborder"]["services"]["chef-client"]
+  service "chef-client" do
     action [:enable, :start]
   end
 else
-  service 'chef-client' do
+  service "chef-client" do
     action [:stop]
   end
 end
 
 #get managers information(name, ip, services...)
-cdomain = ''
+cdomain = ""
 File.open('/etc/redborder/cdomain') {|f| cdomain = f.readline.chomp}
-node.default['redborder']['cdomain'] = cdomain
+node.default["redborder"]["cdomain"] = cdomain
 
 #get managers information(name, ip, services...)
-node.default['redborder']['cluster_info'] = get_cluster_info()
+node.default["redborder"]["cluster_info"] = get_cluster_info()
 
 #get managers sorted by service
-node.default['redborder']['managers_per_services'] = managers_per_service()
+node.default["redborder"]["managers_per_services"] = managers_per_service()
 
 #get elasticache nodes
-elasticache = Chef::DataBagItem.load('rBglobal', 'elasticache') rescue elasticache = {}
+elasticache = Chef::DataBagItem.load("rBglobal", "elasticache") rescue elasticache = {}
 if !elasticache.empty?
-  node.default['redborder']['memcached']['server_list'] = getElasticacheNodes(elasticache['cfg_address'], elasticache['cfg_port'])
-  node.default['redborder']['memcached']['port'] = elasticache['cfg_port']
-  node.default['redborder']['memcached']['hosts'] = joinHostArray2port(node['redborder']['memcached']['server_list'], node['redborder']['memcached']['port']).join(',')
-  node.default['redborder']['memcached']['elasticache'] = true
+  node.default["redborder"]["memcached"]["server_list"] = getElasticacheNodes(elasticache["cfg_address"], elasticache["cfg_port"])
+  node.default["redborder"]["memcached"]["port"] = elasticache["cfg_port"]
+  node.default["redborder"]["memcached"]["hosts"] = joinHostArray2port(node["redborder"]["memcached"]["server_list"], node["redborder"]["memcached"]["port"]).join(",")
+  node.default["redborder"]["memcached"]["elasticache"] = true
 else
-  node.default['redborder']['memcached']['hosts'] = "memcached.service.#{node['redborder']['cdomain']}:#{node['redborder']['memcached']['port']}"
+  node.default["redborder"]["memcached"]["hosts"] = "memcached.service.#{node["redborder"]["cdomain"]}:#{node["redborder"]["memcached"]["port"]}"
 end
 
 #get organizations for http2k
-node.default['redborder']['organizations'] = get_orgs() if node['redborder']['services']['http2k']
+node.default["redborder"]["organizations"] = get_orgs() if node["redborder"]["services"]["http2k"]
 
 #get sensors info
-node.default['redborder']['sensors_info'] = get_sensors_info()
+node.default["redborder"]["sensors_info"] = get_sensors_info()
 
 #get sensors info full info
-node.default['redborder']['sensors_info_all'] = get_sensors_all_info()
+node.default["redborder"]["sensors_info_all"] = get_sensors_all_info()
 
 #get sensors info of all flow sensors
-node.default['redborder']['all_flow_sensors_info'] = get_all_flow_sensors_info()
+node.default["redborder"]["all_flow_sensors_info"] = get_all_flow_sensors_info()
 
 #get logstash pipelines
-node.default['redborder']['logstash']['pipelines'] = get_pipelines()
+node.default["redborder"]["logstash"]["pipelines"] = get_pipelines()
 
 #get namespaces
-node.default['redborder']['namespaces'] = get_namespaces
+node.default["redborder"]["namespaces"] = get_namespaces
 
 #get string with all zookeeper hosts and port separated by commas, its needed for multiples services
-zk_port = node['redborder']['zookeeper']['port']
+zk_port = node["redborder"]["zookeeper"]["port"]
 #zk_hosts = node["redborder"]["managers_per_services"]["zookeeper"].map {|z| "#{z}.node:#{zk_port}"}.join(',')
-node.default['redborder']['zookeeper']['zk_hosts'] = "zookeeper.service.#{node['redborder']['cdomain']}:#{node['redborder']['zookeeper']['port']}"
+node.default["redborder"]["zookeeper"]["zk_hosts"] = "zookeeper.service.#{node["redborder"]["cdomain"]}:#{node["redborder"]["zookeeper"]["port"]}"
 
 #set kafka host index if kafka is enabled in this host
 if node["redborder"]["managers_per_services"]["kafka"].include?(node.name)

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -130,8 +130,7 @@ node.default["redborder"]["manager"]["hd_services_current"] = harddisk_services(
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total)
-
+memory_services(sysmem_total, ['chef-client']) # Don't assign memory to chef because the service will get handled
 
 #License
 

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -130,7 +130,7 @@ node.default["redborder"]["manager"]["hd_services_current"] = harddisk_services(
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, node['redborder']['excluded_memory_services'])
+memory_services(sysmem_total, node.default['redborder']['excluded_memory_services'])
 
 #License
 


### PR DESCRIPTION
Chef client handles other services, so restarting it can be dangerous. Cgroups will restart this service if it is included, that's why we remove it.