### PR TITLE
Bugfix/17236 logstash enabled without pipelines

### DIFF
--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -116,6 +116,12 @@ if node["redborder"]["managers_per_services"]["druid-realtime"].include?(node.na
   node.default["redborder"]["druid"]["realtime"]["partition_num"] = node["redborder"]["managers_per_services"]["druid-realtime"].index(node.name)
 end
 
+if node["redborder"]["logstash"]["pipelines"].empty? and node["redborder"]["services"]["overwrite"].nil?
+  node.default["redborder"]["services"]["logstash"] = false
+else
+  node.default["redborder"]["services"]["logstash"] = true
+end
+
 #get an array of managers
 managers_list = []
 node["redborder"]["cluster_info"].each_key do |mgr|


### PR DESCRIPTION
* When there is no pipelines on the node, logstash start to loop and crash all the time