### PR TITLE
Add configure common cookbook call

### DIFF
--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -6,6 +6,7 @@ description      'Installs/Configures redborder manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.8.0'
 
+depends 'rb-common'
 depends 'chef-server'
 depends 'zookeeper'
 depends 'kafka'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -12,6 +12,10 @@
 # manager services
 manager_services = manager_services()
 
+rb_common_config "Configure common" do
+  action :configure
+end
+
 rb_selinux_config "Configure Selinux" do
   if shell_out("getenforce").stdout.chomp == "Disabled"
     action :remove


### PR DESCRIPTION
- Add a new 'common' cookbook for common settings

Related PRs:
- https://github.com/redBorder/redborder-cookbooks/pull/32
- https://github.com/redBorder/cookbook-rb-common/pull/1
- https://github.com/redBorder/cookbook-rb-proxy/pull/23
- https://github.com/redBorder/redborder-manager/pull/124
- https://github.com/redBorder/cookbook-rb-ips/pull/25