### PR TITLE
Release 2.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-manager CHANGELOG
 ===============
 
+## 2.7.5
+
+  - Pablo Pérez
+    - [58e1061] Revert sync address assignment
+
 ## 2.7.4
 
   - Miguel Negron

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-manager CHANGELOG
 ===============
 
+## 2.7.4
+
+  - Miguel Negron
+    - [d5fd4f7] Avoid upload cookbooks while we fix bug #18576
+
 ## 2.7.3
 
   - Miguel Negrón

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder manager'
-version          '2.7.3'
+version          '2.7.4'
 
 depends 'rb-common'
 depends 'chef-server'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 name             'rb-manager'
 maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder manager'
-version          '2.7.4'
+version          '2.7.5'
 
 depends 'rb-common'
 depends 'chef-server'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -547,11 +547,7 @@ end
 
 rb_ai_config 'Configure redborder-ai' do
   ai_selected_model node['redborder']['ai_selected_model']
-  if node['redborder']['managers_list'].length > 1
-    ipaddress node['ipaddress_sync']
-  else
-    ipaddress node['ipaddress']
-  end
+  ipaddress node['ipaddress_sync']
   if manager_services['redborder-ai']
     action [:add, :register]
   else


### PR DESCRIPTION
Register redborder-ai in consul with sync address as the preference. Change made by @pperezredborder in #194

I could addtionally check that with single nodes (NO SYNC) is taking the management address instead.