### PR TITLE
Bugfix/19032 search for sensors in proxy and enable vault if a vault sensor found

### DIFF
--- a/resources/libraries/get_pipelines.rb
+++ b/resources/libraries/get_pipelines.rb
@@ -6,6 +6,7 @@ module RbManager
       namespaces = get_namespaces()
       main_logstash = determine_main_logstash_node()
       monitor_sensor_in_proxy_nodes = find_monitor_sensor_in_proxy_nodes()
+      vault_sensor_in_proxy_nodes = find_sensor_in_proxy_nodes('vault')
       monitor_config = get_monitor_configuration()
       has_device_sensors = !sensors['device-sensor'].nil? && !sensors['device-sensor'].empty?
 
@@ -14,7 +15,6 @@ module RbManager
       logstash_pipelines.push('scanner-pipeline') unless sensors['scanner-sensor'].empty?
       logstash_pipelines.push('nmsp-pipeline') if main_logstash == node.name && !sensors['flow-sensor'].empty?
       logstash_pipelines.push('radius-pipeline') if main_logstash == node.name
-      logstash_pipelines.push('vault-pipeline') unless sensors['vault-sensor'].empty?
       logstash_pipelines.push('netflow-pipeline') unless sensors['flow-sensor'].empty?
       logstash_pipelines.push('sflow-pipeline') unless sensors['flow-sensor'].empty?
       logstash_pipelines.push('meraki-pipeline') unless sensors['meraki-sensor'].empty?
@@ -28,6 +28,8 @@ module RbManager
         logstash_pipelines.push('location-pipeline')
         logstash_pipelines.push('mobility-pipeline')
       end
+
+      logstash_pipelines.push('vault-pipeline') unless vault_sensor_in_proxy_nodes.empty? && sensors['vault-sensor'].empty?
 
       if (has_device_sensors && monitor_config.include?('thermal')) || !monitor_sensor_in_proxy_nodes.empty?
         logstash_pipelines.push('redfish-pipeline')

--- a/resources/libraries/get_sensor_in_proxy.rb
+++ b/resources/libraries/get_sensor_in_proxy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RbManager
+  module Helpers
+    def find_sensor_in_proxy_nodes(sensor_type)
+      sensors_info = []
+      begin
+        sensors = search(:role, 'run_list:role\[proxy-sensor\]')
+                  .map { |role| role.override_attributes['redborder']['sensors_mapping'][sensor_type.to_s] }
+                  .reject { |s_type| s_type.nil? || s_type.empty? }
+        sensors_info.concat(sensors) unless sensors.empty?
+      rescue NoMethodError
+        sensors_info = []
+      end
+      sensors_info
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://redmine.redborder.lan/issues/19032

- Created a new function to look for sensors in the proxy because the one monitor uses apparently doesn't work
- Introduced the logic to enable vault in the manager when a vault sensor 
is detected in the proxy