### PR TITLE
Bugfix/#19260 wrong check in get sensors all info and get sensors info on  sensores with parent

### DIFF
--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -5,7 +5,7 @@ module RbManager
       sensor_types = %w(ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor vault-sensor flow-sensor arubacentral-sensor mse-sensor meraki-sensor cisco-cloudproxy proxy-sensor scanner-sensor mse-sensor meraki-sensor ale-sensor cep-sensor device-sensor)
 
       sensor_types.each do |s_type|
-        sensors = search(:node, "role:#{s_type}").sort  #get all s_type's sensor
+        sensors = search(:node, "role:#{s_type}").sort  # get all s_type's sensor
 
         sensors_info[s_type] = []
 

--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -10,8 +10,8 @@ module RbManager
         sensors_info[s_type] = []
 
         sensors.each do |sensor|
-          if sensor['parent_id']
-            parent_sensor = search(:node, "id:#{sensor['parent_id']}").first
+          if sensor['redborder_parent_id']
+            parent_sensor = search(:node, "id:#{sensor['redborder_parent_id']}").first
             unless parent_sensor && parent_sensor['role']&.include?('proxy')
               sensors_info[s_type] << sensor
             end

--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -5,10 +5,21 @@ module RbManager
       sensor_types = %w(ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor vault-sensor flow-sensor arubacentral-sensor mse-sensor meraki-sensor cisco-cloudproxy proxy-sensor scanner-sensor mse-sensor meraki-sensor ale-sensor cep-sensor device-sensor)
 
       sensor_types.each do |s_type|
-        sensors = search(:node, "role:#{s_type} AND -redborder_parent_id:*?").sort  # get sensor where parent_id is nil
+        sensors = search(:node, "role:#{s_type}").sort  # get sensor where parent_id is nil or sensor at parent_id is not a proxy
 
         sensors_info[s_type] = []
-        sensors.each { |s| sensors_info[s_type] << s }
+        
+        sensors.each do |sensor|
+
+          if sensor['parent_id']
+            parent_sensor = search(:node,"id:#{sensor['parent_id']}").first
+            unless parent_sensor && parent_sensor['role']&.include?('proxy')
+              sensors_info[s_type] << sensor
+            end
+          else
+            sensors_info[s_type] << sensor
+          end
+        end
       end
 
       sensors_info

--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -10,8 +10,8 @@ module RbManager
         sensors_info[s_type] = []
 
         sensors.each do |sensor|
-          if sensor['redborder_parent_id']
-            parent_sensor = search(:node, "id:#{sensor['redborder_parent_id']}").first
+          if sensor['parent_id']
+            parent_sensor = search(:node, "id:#{sensor['parent_id']}").first
             unless parent_sensor && parent_sensor['role']&.include?('proxy')
               sensors_info[s_type] << sensor
             end

--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -5,19 +5,12 @@ module RbManager
       sensor_types = %w(ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor vault-sensor flow-sensor arubacentral-sensor mse-sensor meraki-sensor cisco-cloudproxy proxy-sensor scanner-sensor mse-sensor meraki-sensor ale-sensor cep-sensor device-sensor)
 
       sensor_types.each do |s_type|
-        sensors = search(:node, "role:#{s_type}").sort  # get sensor where parent_id is nil or sensor at parent_id is not a proxy
+        sensors = search(:node, "role:#{s_type}").sort  #get all s_type's sensor
 
         sensors_info[s_type] = []
 
         sensors.each do |sensor|
-          if sensor['redborder_parent_id']
-            parent_sensor = search(:node, "id:#{sensor['redborder_parent_id']}").first
-            unless parent_sensor && parent_sensor['role']&.include?('proxy')
-              sensors_info[s_type] << sensor
-            end
-          else
-            sensors_info[s_type] << sensor
-          end
+          sensors_info[s_type] << sensor
         end
       end
 

--- a/resources/libraries/get_sensors_all_info.rb
+++ b/resources/libraries/get_sensors_all_info.rb
@@ -8,11 +8,10 @@ module RbManager
         sensors = search(:node, "role:#{s_type}").sort  # get sensor where parent_id is nil or sensor at parent_id is not a proxy
 
         sensors_info[s_type] = []
-        
-        sensors.each do |sensor|
 
+        sensors.each do |sensor|
           if sensor['parent_id']
-            parent_sensor = search(:node,"id:#{sensor['parent_id']}").first
+            parent_sensor = search(:node, "id:#{sensor['parent_id']}").first
             unless parent_sensor && parent_sensor['role']&.include?('proxy')
               sensors_info[s_type] << sensor
             end

--- a/resources/libraries/get_sensors_info.rb
+++ b/resources/libraries/get_sensors_info.rb
@@ -7,7 +7,7 @@ module RbManager
                         ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor)
       locations = node['redborder']['locations']
       sensor_types.each do |s_type|
-        #get all s_type's sensor
+        # get all s_type's sensor
         sensors = search(:node, "role:#{s_type}").sort
         sensors_info[s_type] = {}
         sensors.each do |s|

--- a/resources/libraries/get_sensors_info.rb
+++ b/resources/libraries/get_sensors_info.rb
@@ -13,7 +13,7 @@ module RbManager
         sensors.each do |s|
           if s['redborder_parent_id']
             parent_sensor = search(:node, "id:#{s['redborder_parent_id']}").first
-            next if parent_sensor && parent_sensor['role']&.include?("proxy")
+            next if parent_sensor && parent_sensor['role']&.include?('proxy')
           end
 
           info = {}
@@ -38,7 +38,6 @@ module RbManager
       end
 
       sensors_info
-
     end
   end
 end

--- a/resources/libraries/get_sensors_info.rb
+++ b/resources/libraries/get_sensors_info.rb
@@ -7,10 +7,15 @@ module RbManager
                         ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor)
       locations = node['redborder']['locations']
       sensor_types.each do |s_type|
-        # get sensor where parent_id is nil
-        sensors = search(:node, "role:#{s_type} AND -redborder_parent_id:*?").sort
+        # get sensor where parent_id is nil or sensor at parent_id is not a proxy
+        sensors = search(:node, "role:#{s_type}").sort
         sensors_info[s_type] = {}
         sensors.each do |s|
+          if s['redborder_parent_id']
+            parent_sensor = search(:node, "id:#{s['redborder_parent_id']}").first
+            next if parent_sensor && parent_sensor['role']&.include?("proxy")
+          end
+
           info = {}
           info['name'] = s.name
           info['ip'] = s['ipaddress']
@@ -27,11 +32,13 @@ module RbManager
 
             info['locations'][loc] = s['redborder'][loc]
           end
+
           sensors_info[s_type][s.name] = info
         end
       end
 
       sensors_info
+
     end
   end
 end

--- a/resources/libraries/get_sensors_info.rb
+++ b/resources/libraries/get_sensors_info.rb
@@ -7,15 +7,10 @@ module RbManager
                         ips-sensor ipsv2-sensor ipscp-sensor ipsg-sensor)
       locations = node['redborder']['locations']
       sensor_types.each do |s_type|
-        # get sensor where parent_id is nil or sensor at parent_id is not a proxy
+        #get all s_type's sensor
         sensors = search(:node, "role:#{s_type}").sort
         sensors_info[s_type] = {}
         sensors.each do |s|
-          if s['redborder_parent_id']
-            parent_sensor = search(:node, "id:#{s['redborder_parent_id']}").first
-            next if parent_sensor && parent_sensor['role']&.include?('proxy')
-          end
-
           info = {}
           info['name'] = s.name
           info['ip'] = s['ipaddress']

--- a/resources/libraries/open_kafka_port.rb
+++ b/resources/libraries/open_kafka_port.rb
@@ -2,7 +2,7 @@ module RbManager
   module Helpers
     def get_ip_of_manager_ips
       # IPS in manager mode has the role ips-sensor
-      sensors = search(:node, 'role:ips-sensor AND -redborder_parent_id:*?').sort
+      sensors = search(:node, 'role:ips-sensor').sort
       sensors.map { |s| { ipaddress: s['ipaddress'] } }
     end
 


### PR DESCRIPTION
## Related issue in RedMine

Bugfix/#19260 wrong check in get sensors all info and get sensors info on  sensores with parent [Task](https://redmine.redborder.lan/issues/19260). 

## Description / Motivation

We cannot use parent_id to distinguise when a sensors is part of proxy or to the manager, as a sensor can be inside a domain and has a parent_id.. this bug cause that the logstash intrusion pipeline is not being activated when you register an ips in manager mode.

## Detail

Solved asking if node has redborder_parent_id and then check if there is a proxy.

## Additional information

Fixed open kafka port if there is an IPS manager mode anywhere in the sensors tree.