### PR TITLE
Change definition of vrrp_secrets

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -66,7 +66,7 @@ vrrp_secrets = {}
 
 if manager_services['keepalived']
   begin
-    vrrp_secrets = data_bag_item('passwords', 'vrrp')
+    vrrp_secrets = Chef::EncryptedDataBagItem.load('passwords', 'vrrp').to_hash
   rescue
     vrrp_secrets = {}
   end


### PR DESCRIPTION
Add support for encrypted VRRP secrets in `keepalived_config`. Updated recipe to use `.to_hash` for `EncryptedDataBagItem`, ensuring proper data type compatibility.
