### PR TITLE
bugfix/#21013_Empty_string_on_organizations_megabytes_limit_causes_no_data_from_organizationFix empty string

### DIFF
--- a/resources/libraries/get_orgs.rb
+++ b/resources/libraries/get_orgs.rb
@@ -9,7 +9,11 @@ module RbManager
 
         organizations << m
       end
-
+      organizations.each do |org|
+        if org.override_attributes && org.override_attributes['redborder'] && org.override_attributes['redborder']['megabytes_limit'].is_a?(String) && org.override_attributes['redborder']['megabytes_limit'].strip.empty?
+          org.override_attributes['redborder']['megabytes_limit'] = nil
+        end
+      end
       organizations
     end
   end


### PR DESCRIPTION
## Related issue in RedMine

[Task](https://redmine.redborder.lan/issues/21013)

## Description / Motivation

Initially the task was to fix a bug in the cookbook-http2k. Analysing the problem in depth, it became clear that it is necessary to correct the way this information is saved on the web and in the node, so that it is not saved as an empty string (when it is edited, a value is set and then deleted).

## Detail

Change this where get_orgs.rb is: [cookbook-rb-manager][cookbook-rb-ips][cookbook-rb-intrusion] and [cookbook-rb-proxy]

## Additional information

Also change the webui with a validation on controller.