### PR TITLE
Feature/#21365 Rework consul configuration

### DIFF
--- a/resources/libraries/consul_servers.rb
+++ b/resources/libraries/consul_servers.rb
@@ -1,6 +1,6 @@
 module RbManager
   module Helpers
-    def should_be_consul_server?
+    def consul_server?
       consul_managers = node['redborder']['managers_per_services']['consul']
       hostname = node['hostname']
       total = consul_managers.size

--- a/resources/libraries/get_consul_servers.rb
+++ b/resources/libraries/get_consul_servers.rb
@@ -1,0 +1,19 @@
+module RbManager
+  module Helpers
+    def should_be_consul_server?
+      consul_managers = node['redborder']['managers_per_services']['consul']
+      hostname = node['hostname']
+      total = consul_managers.size
+
+      return true if total == 1
+
+      desired_count = if total.odd?
+                        total
+                      else
+                        total - 1
+                      end
+
+      consul_managers.take(desired_count).include?(hostname)
+    end
+  end
+end

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -14,6 +14,7 @@ node.default['redborder']['manager']['services']['current'] = node.run_state['ma
 virtual_ips = node.run_state['virtual_ips']
 virtual_ips_per_ip = node.run_state['virtual_ips_per_ip']
 user_sensor_map_data = get_user_sensor_map
+is_consul_server = consul_server?
 
 # bash 'upload_cookbooks' do
 #   code 'bash /usr/lib/redborder/bin/rb_upload_cookbooks.sh'
@@ -64,7 +65,7 @@ consul_config 'Configure Consul Server' do
     confdir node['consul']['confdir']
     datadir node['consul']['datadir']
     ipaddress node['ipaddress_sync']
-    is_server should_be_consul_server?
+    is_server is_consul_server
     action :add
   else
     action :remove

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -64,7 +64,7 @@ consul_config 'Configure Consul Server' do
     confdir node['consul']['confdir']
     datadir node['consul']['datadir']
     ipaddress node['ipaddress_sync']
-    (manager_services['consul'] ? (is_server true) : (is_server false))
+    is_server should_be_consul_server?
     action :add
   else
     action :remove


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/21365)

## Description (Refactor way of setting consul servers)

Previously, every manager node with the consul service registered was automatically configured as a Consul server. This could lead to stability and issues, especially with an even number of nodes.

This change improves the logic by dynamically assigning an odd number of servers based on the total number of consul manager nodes. 

<html><head></head><body>
Total Consul Nodes | Servers Assigned | Example Nodes Assigned as Server
-- | -- | --
1 | 1 | node 1
2 | 1 | node 1
3 | 3 | nodes 1, 2, 3
4 | 3 | nodes 1, 2, 3
5 | 5 | nodes 1, 2, 3, 4, 5
6 | 5 | nodes 1, 2, 3, 4, 5

</body></html>