### PR TITLE
Bugfix/#21781 Generate key .rsa with chef in ~/.ssh/ and use it in rbcli instead of using the rails one

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -766,7 +766,7 @@ directory '/root/.ssh' do
 end
 
 unless ssh_secrets.empty?
-  template '/root/.ssh/rsa.pub' do
+  template '/root/.ssh/authorized_keys' do
     source 'rsa.pub.erb'
     owner 'root'
     group 'root'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -779,7 +779,7 @@ end
 begin
   rsa_pem = data_bag_item('certs', 'rsa_pem')
 rescue
-  rsa_pem = nil
+  rsa_pem = {}
 end
 
 unless rsa_pem.empty?

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -766,13 +766,30 @@ directory '/root/.ssh' do
 end
 
 unless ssh_secrets.empty?
-  template '/root/.ssh/authorized_keys' do
+  template '/root/.ssh/rsa.pub' do
     source 'rsa.pub.erb'
     owner 'root'
     group 'root'
     mode '0600'
     retries 2
     variables(public_rsa: ssh_secrets['public_rsa'])
+  end
+end
+
+begin
+  rsa_pem = data_bag_item('certs', 'rsa_pem')
+rescue
+  rsa_pem = nil
+end
+
+unless rsa_pem.empty?
+  template '/root/.ssh/rsa' do
+    source 'rsa_cert.pem.erb'
+    owner 'root'
+    group 'root'
+    mode '0600'
+    retries 2
+    variables(private_rsa: rsa_pem['private_rsa'])
   end
 end
 

--- a/resources/templates/default/rsa_cert.pem.erb
+++ b/resources/templates/default/rsa_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= @private_rsa.strip %>


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/21781)

## Description

Creating **private rsa** at `/root/.ssh/rsa`.