### PR TITLE
Bugfix/22236 scanner profile started in proxy runs in manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-manager CHANGELOG
 ===============
 
+## 5.6.0
+
+  - Pablo Torres
+    - [e6961e6] Improvement #21846: remove custom dimensions
+
 ## 5.5.0
 
   - Rafael Gomez

--- a/resources/libraries/get_indexer_tasks.rb
+++ b/resources/libraries/get_indexer_tasks.rb
@@ -12,28 +12,17 @@ module RbManager
         { task_name: 'rb_wireless', feed: 'rb_wireless' },
       ]
 
-      dimensions = {}
-      Dir.glob('/var/rb-extensions/*/dimensions.yml') do |item|
-        begin
-          dimensions.merge!(YAML.load_file(item))
-        rescue
-          dimensions
-        end
-      end
-
       kafka_brokers = node['redborder']['managers_per_services']['kafka']
       kafka_brokers = kafka_brokers.map { |broker| "#{broker}.node:9092" }
       namespaces = node.run_state['namespaces']
 
       base_tasks.flat_map do |task|
         default_task = { spec: task[:task_name], task_name: task[:task_name], namespace: '', feed: task[:feed], kafka_brokers: kafka_brokers }
-        default_task[:custom_dimensions] = dimensions.keys if task[:task_name] == 'rb_vault'
 
         namespace_tasks = namespaces.map do |namespace|
           taskHash = { spec: task[:task_name], task_name: task[:task_name] + '_' + namespace, namespace: namespace, kafka_brokers: kafka_brokers }
           taskHash[:feed] = task[:feed] + '_' + namespace
           taskHash[:feed] = 'rb_monitor_post_' + namespace if task[:task_name] == 'rb_monitor'
-          taskHash[:custom_dimensions] = dimensions.keys if task[:task_name] == 'rb_vault'
           taskHash
         end
 

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder manager'
-version          '5.5.0'
+version          '5.6.0'
 
 depends 'rb-common'
 depends 'chef-server'

--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -275,7 +275,7 @@ end
 rb_druid_indexer_config 'Configure Rb Druid Indexer' do
   if manager_services['rb-druid-indexer']
     zk_hosts node['redborder']['managers_per_services']['zookeeper']
-    tasks node['redborder']['druid-indexer-tasks']
+    tasks node.default['redborder']['druid-indexer-tasks']
     action [:add, :register]
   else
     action [:remove, :deregister]
@@ -289,7 +289,7 @@ druid_indexer 'Configure Druid Indexer' do
     ipaddress node['ipaddress_sync']
     memory_kb node['redborder']['memory_services']['druid-indexer']['memory']
     cpu_num node['cpu']['total'].to_i
-    tasks node['redborder']['druid-indexer-tasks']
+    tasks node.default['redborder']['druid-indexer-tasks']
     s3_secrets s3_secrets
     action [:add, :register]
   else


### PR DESCRIPTION
get_cluster_sensors_info is a function that returns the sensors (not a specific array/hash) that are only in the cluster, meaning only sensors that are in managers, not in proxies or ips