### PR TITLE
bugfix/22553/add-ntp-servers-configured-in-the-platform

### DIFF
--- a/resources/recipes/configure.rb
+++ b/resources/recipes/configure.rb
@@ -709,11 +709,38 @@ rb_clamav_config 'Configure ClamAV' do
   action :add
 end
 
-rb_chrony_config 'Configure Chrony' do
-  if manager_services['chrony']
-    ntp_servers node['redborder']['ntp']['servers']
+# Configure Chrony
+servers = []
+
+if manager_services['chrony']
+  servers = node['redborder']['ntp']['servers'] || []
+
+  begin
+    sensor_role = Chef::Role.load('sensor')
+    sensor_role.override_attributes['redborder'] ||= {}
+    sensor_role.override_attributes['redborder']['ntp'] ||= {}
+    sensor_role.override_attributes['redborder']['ntp']['servers'] = servers
+    sensor_role.save
+    Chef::Log.info("Configure Chrony: Propagated NTP servers to sensor's role: #{servers}")
+  rescue => e
+    Chef::Log.error("Configure Chrony: Failed to update role 'sensor': #{e.message}")
+  end
+
+  rb_chrony_config 'Configure Chrony' do
+    ntp_servers servers
     action :add
-  else
+  end
+
+else
+  sensor_role = search(:role, 'name:sensor').first rescue nil
+  servers = sensor_role&.override_attributes&.dig('redborder','ntp','servers') || []
+
+  if servers.empty?
+    servers = node['chrony']['ntp_servers'] || []
+    Chef::Log.warn("Configure Chrony: No NTP servers found in node or sensor role, using defaults: #{servers}")
+  end
+  
+  rb_chrony_config 'Configure Chrony' do
     action :remove
   end
 end


### PR DESCRIPTION
## Related issue in RedMine

Replace this text with the title of the RedMine task and the link to the ticket. To know more about working with RedMine, you should visit [this](https://docs.google.com/document/d/1f1vARFG-5Cz3rfRBlkLfq8K1deLv8jPxW04SqMyW--w/edit#heading=h.ofrjxgmkpftw) and [this](https://docs.google.com/document/d/1rEDNJ2YWBhhfRoL1xdSQMq44byRcTATfQmUmwZMzIFM/edit?tab=t.0).

## Description / Motivation

the ntp servers configured in the platform (general settings) are not applied in the proxy and ips sensors. The default ntp servers are always applied

In case the sensors are out of the network, there should be a possibility to overrule them on the level of the sensor (ips and proxy)


## Detail

Configure Chrony: Propagated NTP servers to sensor's role
