### PR TITLE
Bugfix/#22675 change aerospike port

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -44,7 +44,7 @@ default['redis']['port'] = 26379
 default['redis']['sentinel_port'] = 26380
 
 # aerospike
-default['aerospike']['port'] = 5000
+default['aerospike']['port'] = 3000
 default['aerospike']['multicast'] = '239.1.99.222'
 
 # hard disk


### PR DESCRIPTION
The Legacy and the aerospike port by default is 3000. No sense to change to 5000