### PR TITLE
Bugfix/#22661 Aerospike service is enabled by default

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -103,7 +103,7 @@ default['redborder']['memory_assigned'] = {}
 # geoip has been removed because is not a service
 default['redborder']['services_group']['full'] = %w(consul chef-server zookeeper memcached rsyslog kafka logstash s3
                                                     druid-broker druid-historical druid-coordinator druid-router druid-indexer druid-overlord
-                                                    postgresql aerospike nginx webui rb-workers f2k rb-druid-indexer
+                                                    postgresql nginx webui rb-workers f2k rb-druid-indexer
                                                     redborder-monitor sfacctd redborder-dswatcher redis
                                                     redborder-events-counter http2k redborder-mem2incident rb-logstatter)
 
@@ -121,7 +121,7 @@ default['redborder']['services_group']['s3'] = %w(consul nginx s3)
 default['redborder']['services_group']['postgresql'] = %w(consul postgresql)
 
 default['redborder']['services'] = {}
-default['redborder']['services']['aerospike']                 = true
+default['redborder']['services']['aerospike']                 = false
 default['redborder']['services']['chef-client']               = true
 default['redborder']['services']['chef-server']               = false
 default['redborder']['services']['chrony']                    = true


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/22661)

## Description

`Aerospike` service should is disabled by default, at least until all malware is finished.